### PR TITLE
Check number of validator connections before finalizing blocks

### DIFF
--- a/blockchain/notifications.go
+++ b/blockchain/notifications.go
@@ -18,23 +18,24 @@ type NotificationType int
 // execute the callback with the state lock held to prevent races.
 type NotificationCallback func(*Notification)
 
-// Constants for the type of a notification message. We only have one now
-// maybe we'll add others later so we put the plumbing here for it.
+// Constants for the type of notification message
 const (
 	// NTBlockConnected indicates the associated block was connected to the chain.
 	NTBlockConnected = iota
 	NTAddValidator
 	NTRemoveValidator
+	NTValidatorSetUpdate
 	NTNewEpoch
 )
 
 // notificationTypeStrings is a map of notification types back to their constant
 // names for pretty printing.
 var notificationTypeStrings = map[NotificationType]string{
-	NTBlockConnected:  "NTBlockConnected",
-	NTAddValidator:    "NTAddValidator",
-	NTRemoveValidator: "NTRemoveValidator",
-	NTNewEpoch:        "NTNewEpoch",
+	NTBlockConnected:     "NTBlockConnected",
+	NTAddValidator:       "NTAddValidator",
+	NTRemoveValidator:    "NTRemoveValidator",
+	NTValidatorSetUpdate: "NTValidatorSetUpdate",
+	NTNewEpoch:           "NTNewEpoch",
 }
 
 // String returns the NotificationType in human-readable form.

--- a/consensus/chooser.go
+++ b/consensus/chooser.go
@@ -75,6 +75,9 @@ func (b *BackoffChooser) RegisterDialFailure(p peer.ID) {
 // RegisterDialSuccess deletes the exponential backoff for the
 // given peer.
 func (b *BackoffChooser) RegisterDialSuccess(p peer.ID) {
-	log.Debugf("[CONSENSUS] removing backoff for peer %s", p.String())
-	delete(b.peerMap, p)
+	_, ok := b.peerMap[p]
+	if ok {
+		log.Debugf("[CONSENSUS] removing backoff from peer %s", p.String())
+		delete(b.peerMap, p)
+	}
 }

--- a/consensus/engine_test.go
+++ b/consensus/engine_test.go
@@ -38,6 +38,12 @@ func (m *MockChooser) WeightedRandomValidator() peer.ID {
 	return peers[i]
 }
 
+type MockValConn struct{}
+
+func (m *MockValConn) ConnectedStakePercentage() float64 {
+	return 100
+}
+
 type mockNode struct {
 	engine *ConsensusEngine
 }
@@ -65,6 +71,7 @@ func newMockNode(mn mocknet.Mocknet) (*mockNode, error) {
 	engine, err := NewConsensusEngine(context.Background(),
 		Params(&params.RegestParams),
 		Network(network),
+		ValidatorConnector(&MockValConn{}),
 		Chooser(&MockChooser{network: network}),
 		HasBlock(func(id types.ID) bool { return false }),
 		RequestBlock(func(id types.ID, id2 peer.ID) {}),

--- a/consensus/options.go
+++ b/consensus/options.go
@@ -56,6 +56,13 @@ func Chooser(chooser blockchain.WeightedChooser) Option {
 	}
 }
 
+func ValidatorConnector(valConn ValidatorSetConnection) Option {
+	return func(cfg *config) error {
+		cfg.valConn = valConn
+		return nil
+	}
+}
+
 // RequestBlock is a function which requests to download a block
 // from the given peer.
 //
@@ -92,6 +99,7 @@ func PeerID(self peer.ID) Option {
 type config struct {
 	params       *params.NetworkParams
 	network      *net.Network
+	valConn      ValidatorSetConnection
 	chooser      blockchain.WeightedChooser
 	self         peer.ID
 	requestBlock RequestBlockFunc
@@ -107,6 +115,9 @@ func (cfg *config) validate() error {
 	}
 	if cfg.network == nil {
 		return AssertError("NewConsensusEngine: network cannot be nil")
+	}
+	if cfg.valConn == nil {
+		return AssertError("NewConsensusEngine: validator connector cannot be nil")
 	}
 	if cfg.chooser == nil {
 		return AssertError("NewConsensusEngine: chooser cannot be nil")

--- a/consensus/valconn.go
+++ b/consensus/valconn.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2022 The illium developers
+// Use of this source code is governed by an MIT
+// license that can be found in the LICENSE file.
+
+package consensus
+
+type ValidatorSetConnection interface {
+	ConnectedStakePercentage() float64
+}

--- a/net/validator_connector.go
+++ b/net/validator_connector.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2022 The illium developers
+// Use of this source code is governed by an MIT
+// license that can be found in the LICENSE file.
+
+package net
+
+import (
+	"context"
+	inet "github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	routedhost "github.com/libp2p/go-libp2p/p2p/host/routed"
+	"github.com/project-illium/ilxd/blockchain"
+	"github.com/project-illium/ilxd/types"
+	"sync"
+	"time"
+)
+
+// ValidatorConnector does two things.
+// First, it strives to maintain active connections to all validators in the
+// validator set.
+// Second, it tracks the percentage of the weighted stake that we are connected to.
+type ValidatorConnector struct {
+	ownID               peer.ID
+	connectedPercentage float64
+	getValidatorFunc    func(validatorID peer.ID) (*blockchain.Validator, error)
+	getValidatorsFunc   func() []*blockchain.Validator
+	host                *routedhost.RoutedHost
+	mtx                 sync.RWMutex
+}
+
+// NewValidatorConnector returns a new ValidatorConnector
+func NewValidatorConnector(host *routedhost.RoutedHost, ownID peer.ID,
+	getValidatorFunc func(validatorID peer.ID) (*blockchain.Validator, error),
+	getValidatorsFunc func() []*blockchain.Validator) *ValidatorConnector {
+
+	vc := &ValidatorConnector{
+		ownID:             ownID,
+		getValidatorFunc:  getValidatorFunc,
+		getValidatorsFunc: getValidatorsFunc,
+		host:              host,
+		mtx:               sync.RWMutex{},
+	}
+
+	go vc.run()
+	return vc
+}
+
+// ConnectedStakePercentage returns the percentage of the weighted stake that
+// we are connected to.
+func (vc *ValidatorConnector) ConnectedStakePercentage() float64 {
+	vc.mtx.RLock()
+	defer vc.mtx.RUnlock()
+
+	return vc.connectedPercentage
+}
+
+func (vc *ValidatorConnector) run() {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for ; true; <-ticker.C {
+		vc.update()
+	}
+}
+
+func (vc *ValidatorConnector) update() {
+	totalStake := types.Amount(0)
+	connectedStake := types.Amount(0)
+	if val, err := vc.getValidatorFunc(vc.ownID); err == nil {
+		connectedStake = val.WeightedStake
+	}
+
+	for _, val := range vc.getValidatorsFunc() {
+		totalStake += val.WeightedStake
+
+		switch vc.host.Network().Connectedness(val.PeerID) {
+		case inet.Connected:
+			if val.PeerID != vc.ownID {
+				connectedStake += val.WeightedStake
+			}
+		case inet.NotConnected, inet.CanConnect:
+			if val.PeerID != vc.ownID {
+				go vc.host.Connect(context.Background(), peer.AddrInfo{ID: val.PeerID})
+			}
+		}
+
+	}
+
+	vc.mtx.Lock()
+	vc.connectedPercentage = float64(connectedStake) / float64(totalStake)
+	vc.mtx.Unlock()
+}
+
+func (vc *ValidatorConnector) handleBlockchainNotification(ntf *blockchain.Notification) {
+	if ntf.Type == blockchain.NTValidatorSetUpdate {
+		vc.update()
+	}
+}
+
+func (vc *ValidatorConnector) handlePeerConnected(_ inet.Network, conn inet.Conn) {
+	_, err := vc.getValidatorFunc(conn.RemotePeer())
+	if err == nil {
+		vc.update()
+	}
+}
+
+func (vc *ValidatorConnector) handlePeerDisconnected(_ inet.Network, conn inet.Conn) {
+	_, err := vc.getValidatorFunc(conn.RemotePeer())
+	if err == nil {
+		vc.update()
+	}
+}

--- a/server.go
+++ b/server.go
@@ -15,6 +15,7 @@ import (
 	golog "github.com/ipfs/go-log"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
+	routedhost "github.com/libp2p/go-libp2p/p2p/host/routed"
 	"github.com/project-illium/ilxd/blockchain"
 	"github.com/project-illium/ilxd/blockchain/indexers"
 	"github.com/project-illium/ilxd/consensus"
@@ -327,9 +328,12 @@ func BuildServer(config *repo.Config) (*Server, error) {
 		return nil, err
 	}
 
+	valConn := net.NewValidatorConnector(routedhost.Wrap(network.Host(), network.Dht()), hostID, chain.GetValidator, chain.Validators)
+
 	engine, err := consensus.NewConsensusEngine(ctx, []consensus.Option{
 		consensus.Params(netParams),
 		consensus.Network(network),
+		consensus.ValidatorConnector(valConn),
 		consensus.Chooser(chain),
 		consensus.RequestBlock(s.requestBlock),
 		consensus.HasBlock(chain.HasBlock),


### PR DESCRIPTION
This commit adds a new ValidatorConnector class that manages maintaining connections to the validators.

The consensus engine is also modified to check if we are connected to >50% of the validator set before sending out queries.

The purpose of this is to prevent a node (that has stake) from finalizing blocks by itself and forking itself off the network in the event it can't make outgoing connections.