### PR TITLE
Refactor checksig coprocessor

### DIFF
--- a/zk/lurk/macros/deps/std/mod.lurk
+++ b/zk/lurk/macros/deps/std/mod.lurk
@@ -1,12 +1,18 @@
 !(module crypto (
-        ;; check-sig verifies the signature covering the sig-hash against
+        ;; checksig verifies the signature covering the sighash against
         ;; the provided public key. This function uses the Nova signature
         ;; algorithm with the Vesta Curve.
         ;;
-        ;; signature - (cons sig-r sig-s)
-        ;; pubkey    - (cons pubkey-x-coordinate pubkey-y-coordinate)
-        ;; sighash   - blake2slurk hash
-        !(defun check-sig (signature pubkey sighash) (
-                (eval (cons 'check_ecc_sig (cons (car signature) (cons (car (cdr signature)) (cons (car pubkey) (cons (car (cdr pubkey)) (cons sighash nil)))))))
+        ;; sig       - (cons sig-rx (cons sig-ry (cons sig-s nil)))
+        ;; pubkey    - (cons pubkey-x pubkey-y)
+        ;; sighash   - blake2s-hash
+        ;;
+        ;; return t or nil
+        ;;
+        ;; Note: nil will only be returned if the signature if properly
+        ;; formatted but invalid. Proving will fail if the signature is
+        ;; malformatted.
+        !(defun checksig (sig pubkey sighash) (
+                (eval (cons 'coproc_checksig (cons (car sig) (cons (car (cdr sig)) (cons (car (cdr (cdr sig))) (cons (car pubkey) (cons (car (cdr pubkey)) (cons sighash nil))))))))
         ))
 ))

--- a/zk/lurk/macros/preprocessor_test.go
+++ b/zk/lurk/macros/preprocessor_test.go
@@ -301,6 +301,6 @@ func TestWithStandardLib(t *testing.T) {
 	lurkProgram = strings.ReplaceAll(lurkProgram, "\t", "")
 	lurkProgram = strings.Join(strings.Fields(lurkProgram), " ")
 	assert.True(t, isValid(lurkProgram))
-	expected := `(letrec ((my-func (lambda (y) (letrec ((check-sig (lambda (signature pubkey sighash) (eval (cons 'check_ecc_sig (cons (car signature) (cons (car (cdr signature)) (cons (car pubkey) (cons (car (cdr pubkey)) (cons sighash nil))))))) )))(check-sig 10))))))`
+	expected := `(letrec ((my-func (lambda (y) (letrec ((checksig (lambda (sig pubkey sighash) (eval (cons 'coproc_checksig (cons (car sig) (cons (car (cdr sig)) (cons (car (cdr (cdr sig))) (cons (car pubkey) (cons (car (cdr pubkey)) (cons sighash nil)))))))) )))(check-sig 10))))))`
 	assert.Equal(t, expected, lurkProgram)
 }

--- a/zk/proofs_test.go
+++ b/zk/proofs_test.go
@@ -60,8 +60,8 @@ func TestCoprocessors(t *testing.T) {
 		h := hash.HashMerkleBranches(left[:], right[:])
 
 		program := fmt.Sprintf(`(lambda (priv pub) (letrec ((cat-and-hash (lambda (a b)
-                                    (eval (cons 'coproc_blake2s (cons a (cons b nil)))))))
-                            (= (cat-and-hash priv pub) 0x%x)))`, h)
+                                    			(eval (cons 'coproc_blake2s (cons a (cons b nil)))))))
+											(= (cat-and-hash priv pub) 0x%x)))`, h)
 
 		proof, err := Prove(program, Expr(fmt.Sprintf("0x%x", left)), Expr(fmt.Sprintf("0x%x", right)))
 		assert.NoError(t, err)

--- a/zk/rust/src/coprocessors/ecc.rs
+++ b/zk/rust/src/coprocessors/ecc.rs
@@ -88,6 +88,7 @@ impl<F> AllocatedPoint<F>
         }
 
     /// checks if `self` is on the curve or if it is infinity
+    #[allow(dead_code)]
     pub fn check_on_curve<CS>(&self, mut cs: CS) -> Result<(), SynthesisError>
         where
             CS: ConstraintSystem<F>,
@@ -634,11 +635,13 @@ impl<F> AllocatedPointNonInfinity<F>
         F: PrimeField,
 {
     /// Creates a new `AllocatedPointNonInfinity` from the specified coordinates
+    #[allow(dead_code)]
     pub const fn new(x: AllocatedNum<F>, y: AllocatedNum<F>) -> Self {
         Self { x, y }
     }
 
     /// Allocates a new point on the curve using coordinates provided by `coords`.
+    #[allow(dead_code)]
     pub fn alloc<CS: ConstraintSystem<F>>(
         mut cs: CS,
         coords: Option<(F, F)>,
@@ -674,6 +677,7 @@ impl<F> AllocatedPointNonInfinity<F>
     }
 
     /// Returns coordinates associated with the point.
+    #[allow(dead_code)]
     pub const fn get_coordinates(&self) -> (&AllocatedNum<F>, &AllocatedNum<F>) {
         (&self.x, &self.y)
     }

--- a/zk/rust/src/lib.rs
+++ b/zk/rust/src/lib.rs
@@ -15,7 +15,7 @@ use lurk::{
     eval::lang::{Lang, Coproc},
     field::LurkField,
     lem::{
-        eval::{evaluate, evaluate_simple, make_eval_step_from_config, EvalConfig},
+        eval::{evaluate, evaluate_simple, make_cprocs_funcs_from_lang, make_eval_step_from_config, EvalConfig},
         multiframe::MultiFrame,
         store::Store,
     },
@@ -232,7 +232,6 @@ fn create_proof(lurk_program: String, private_params: String, public_params: Str
 
     let call = store.read_with_default_state(expr.as_str())?;
 
-
     let mut lang = Lang::<Fr, MultiCoproc<Fr>>::new();
     lang.add_coprocessor(cproc_sym_xor, XorCoprocessor::new());
     lang.add_coprocessor(cproc_sym_checksig, ChecksigCoprocessor::new());
@@ -240,7 +239,8 @@ fn create_proof(lurk_program: String, private_params: String, public_params: Str
     let lang_rc = Arc::new(lang.clone());
 
     let lurk_step = make_eval_step_from_config(&EvalConfig::new_nivc(&lang));
-    let frames = evaluate(Some((&lurk_step, &lang)), call, store, max_steps).unwrap();
+    let cprocs = make_cprocs_funcs_from_lang(&lang);
+    let frames = evaluate(Some((&lurk_step, &cprocs, &lang)), call, store, max_steps).unwrap();
 
     let supernova_prover = SuperNovaProver::<Fr, MultiCoproc<Fr>, MultiFrame<'_, _, _>>::new(
         REDUCTION_COUNT,


### PR DESCRIPTION
The original design of the coprocessor would enforce constraints such that the proof would be invalid if the signature is invalid. That is mostly OK for our use case but it would provide more flexibility to users of the script if the checksig function returned nil (false) if the signature is invalid. 

This PR makes that change. The proof will still fail if the signature is malformatted (like not on the curve) but it will return nil if it's a correctly formatted but invalid signature. 