### PR TITLE
Create cuda go build tag

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,8 +11,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    container:
-      image: nvidia/cuda:12.3.0-devel-ubuntu20.04
 
     steps:
       - uses: actions/checkout@v3
@@ -20,10 +18,10 @@ jobs:
       - name: Install dependencies
         run: |
           export DEBIAN_FRONTEND=noninteractive
-          apt-get update
-          apt-get install -y curl wget build-essential pkg-config libssl-dev
-          ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime
-          dpkg-reconfigure --frontend noninteractive tzdata
+          sudo apt-get update
+          sudo apt-get install -y curl wget build-essential pkg-config libssl-dev
+          sudo ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime
+          sudo dpkg-reconfigure --frontend noninteractive tzdata
 
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -41,10 +39,6 @@ jobs:
           which go
           which gcc
           gcc --version
-          ls -l /usr/local/cuda/targets/x86_64-linux/lib/
-          export LD_LIBRARY_PATH=/usr/local/cuda/targets/x86_64-linux/lib:${LD_LIBRARY_PATH}
-          export CGO_CFLAGS="-I/usr/local/cuda/include"
-          export CGO_LDFLAGS="-L/usr/local/cuda/targets/x86_64-linux/lib -lcudart"
           make build VERBOSE=1
 
       - name: Test

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ a production environment please checkout a release tag.
 
 Make sure you have the required dependencies:
 ```go
-$ apt-get install curl wget build-essential pkg-config libssl-dev nvidia-cuda-toolkit
+$ apt-get install curl wget build-essential pkg-config libssl-dev
 ```
 
 Ilxd requires both Go and Rust to be installed on your system. You'll need to use the makefile to install it as it will

--- a/crypto/nova.go
+++ b/crypto/nova.go
@@ -9,7 +9,7 @@ package crypto
 
 /*
 #cgo linux CFLAGS: -Irust/target/release -Irust-target-release-crypto
-#cgo linux LDFLAGS: -Lrust/target/release -Lrust-target-release-crypto -l:libillium_crypto.a -ldl -lpthread -lgcc_s -lc -lm -lssl -lcrypto -lstdc++ -L/usr/local/cuda/lib64 -L/usr/local/cuda/targets/x86_64-linux/lib -lcudart
+#cgo linux LDFLAGS: -Lrust/target/release -Lrust-target-release-crypto -l:libillium_crypto.a -ldl -lpthread -lgcc_s -lc -lm -lssl -lcrypto -lstdc++
 #cgo windows CFLAGS: -Irust/target/release
 #cgo windows LDFLAGS: -Lrust/target/release -l:illium_crypto.lib
 #cgo darwin CFLAGS: -Irust/target/release -Irust/target/x86_64-apple-darwin/release

--- a/zk/cgo_cuda.go
+++ b/zk/cgo_cuda.go
@@ -1,0 +1,18 @@
+//go:build cuda
+// +build cuda
+
+// Copyright (c) 2024 The illium developers
+// Use of this source code is governed by an MIT
+// license that can be found in the LICENSE file.
+
+package zk
+
+/*
+#cgo linux CFLAGS: -Irust/target/release -Irust-target-release-zk
+#cgo linux LDFLAGS: -Lrust/target/release -Lrust-target-release-zk -l:libillium_zk.a -ldl -lpthread -lgcc_s -lc -lm -lssl -lcrypto -lstdc++ -L/usr/local/cuda/lib64 -L/usr/local/cuda/targets/x86_64-linux/lib -lcudart
+#cgo windows CFLAGS: -Irust/target/release
+#cgo windows LDFLAGS: -Lrust/target/release -l:libillium_zk.lib
+#cgo darwin CFLAGS: -Irust/target/release -Irust/target/x86_64-apple-darwin/release
+#cgo darwin LDFLAGS: -Lrust/target/release -Lrust/target/x86_64-apple-darwin/release -lillium_zk -lc++ -lssl -lcrypto -framework SystemConfiguration
+*/
+import "C"

--- a/zk/cgo_nocuda.go
+++ b/zk/cgo_nocuda.go
@@ -14,46 +14,5 @@ package zk
 #cgo windows LDFLAGS: -Lrust/target/release -l:libillium_zk.lib
 #cgo darwin CFLAGS: -Irust/target/release -Irust/target/x86_64-apple-darwin/release
 #cgo darwin LDFLAGS: -Lrust/target/release -Lrust/target/x86_64-apple-darwin/release -lillium_zk -lc++ -lssl -lcrypto -framework SystemConfiguration
-#include <stdlib.h>
-#include <stdint.h>
-#include <unistd.h>
-#include <fcntl.h>
-extern int lurk_commit(const char* expr, unsigned char* out);
-// Function to save the current stderr file descriptor and redirect stderr to /dev/null
-int redirect_stderr() {
-    int stderr_copy = dup(2);
-    int dev_null = open("/dev/null", O_WRONLY);
-    dup2(dev_null, 2);
-    close(dev_null);
-    return stderr_copy;
-}
-// Function to restore stderr from the saved file descriptor
-void restore_stderr(int stderr_copy) {
-    dup2(stderr_copy, 2);
-    close(stderr_copy);
-}
-void load_public_params();
-int create_proof_ffi(
-    const char* lurk_program,
-    const char* private_params,
-    const char* public_params,
-    uint8_t* proof,
-    size_t* proof_len,
-    uint8_t* output_tag,
-    uint8_t* output_val);
-int verify_proof_ffi(
-    const char* lurk_program,
-    const char* public_params,
-    const uint8_t* proof,
-    size_t proof_size,
-    const uint8_t* expected_tag,
-    const uint8_t* expected_output);
-int eval_ffi(
-    const char* lurk_program,
-    const char* private_params,
-    const char* public_params,
-    uint8_t* output_tag,
-    uint8_t* output_val,
-	size_t* iterations);
 */
 import "C"

--- a/zk/cgo_nocuda.go
+++ b/zk/cgo_nocuda.go
@@ -1,0 +1,59 @@
+//go:build !cuda
+// +build !cuda
+
+// Copyright (c) 2024 The illium developers
+// Use of this source code is governed by an MIT
+// license that can be found in the LICENSE file.
+
+package zk
+
+/*
+#cgo linux CFLAGS: -Irust/target/release -Irust-target-release-zk
+#cgo linux LDFLAGS: -Lrust/target/release -Lrust-target-release-zk -l:libillium_zk.a -ldl -lpthread -lgcc_s -lc -lm -lssl -lcrypto -lstdc++
+#cgo windows CFLAGS: -Irust/target/release
+#cgo windows LDFLAGS: -Lrust/target/release -l:libillium_zk.lib
+#cgo darwin CFLAGS: -Irust/target/release -Irust/target/x86_64-apple-darwin/release
+#cgo darwin LDFLAGS: -Lrust/target/release -Lrust/target/x86_64-apple-darwin/release -lillium_zk -lc++ -lssl -lcrypto -framework SystemConfiguration
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <fcntl.h>
+extern int lurk_commit(const char* expr, unsigned char* out);
+// Function to save the current stderr file descriptor and redirect stderr to /dev/null
+int redirect_stderr() {
+    int stderr_copy = dup(2);
+    int dev_null = open("/dev/null", O_WRONLY);
+    dup2(dev_null, 2);
+    close(dev_null);
+    return stderr_copy;
+}
+// Function to restore stderr from the saved file descriptor
+void restore_stderr(int stderr_copy) {
+    dup2(stderr_copy, 2);
+    close(stderr_copy);
+}
+void load_public_params();
+int create_proof_ffi(
+    const char* lurk_program,
+    const char* private_params,
+    const char* public_params,
+    uint8_t* proof,
+    size_t* proof_len,
+    uint8_t* output_tag,
+    uint8_t* output_val);
+int verify_proof_ffi(
+    const char* lurk_program,
+    const char* public_params,
+    const uint8_t* proof,
+    size_t proof_size,
+    const uint8_t* expected_tag,
+    const uint8_t* expected_output);
+int eval_ffi(
+    const char* lurk_program,
+    const char* private_params,
+    const char* public_params,
+    uint8_t* output_tag,
+    uint8_t* output_val,
+	size_t* iterations);
+*/
+import "C"

--- a/zk/commitment.go
+++ b/zk/commitment.go
@@ -1,6 +1,3 @@
-//go:build !skiprusttests
-// +build !skiprusttests
-
 // Copyright (c) 2024 The illium developers
 // Use of this source code is governed by an MIT
 // license that can be found in the LICENSE file.
@@ -8,12 +5,6 @@
 package zk
 
 /*
-#cgo linux CFLAGS: -Irust/target/release -Irust-target-release-zk
-#cgo linux LDFLAGS: -Lrust/target/release -Lrust-target-release-zk -l:libillium_zk.a -ldl -lpthread -lgcc_s -lc -lm -lssl -lcrypto -lstdc++
-#cgo windows CFLAGS: -Irust/target/release
-#cgo windows LDFLAGS: -Lrust/target/release -l:libillium_zk.lib
-#cgo darwin CFLAGS: -Irust/target/release -Irust/target/x86_64-apple-darwin/release
-#cgo darwin LDFLAGS: -Lrust/target/release -Lrust/target/x86_64-apple-darwin/release -lillium_zk -lc++ -lssl -lcrypto -framework SystemConfiguration
 #include <stdlib.h>
 extern int lurk_commit(const char* expr, unsigned char* out);
 */

--- a/zk/commitment.go
+++ b/zk/commitment.go
@@ -9,7 +9,7 @@ package zk
 
 /*
 #cgo linux CFLAGS: -Irust/target/release -Irust-target-release-zk
-#cgo linux LDFLAGS: -Lrust/target/release -Lrust-target-release-zk -l:libillium_zk.a -ldl -lpthread -lgcc_s -lc -lm -lssl -lcrypto -lstdc++ -L/usr/local/cuda/lib64 -L/usr/local/cuda/targets/x86_64-linux/lib -lcudart
+#cgo linux LDFLAGS: -Lrust/target/release -Lrust-target-release-zk -l:libillium_zk.a -ldl -lpthread -lgcc_s -lc -lm -lssl -lcrypto -lstdc++
 #cgo windows CFLAGS: -Irust/target/release
 #cgo windows LDFLAGS: -Lrust/target/release -l:libillium_zk.lib
 #cgo darwin CFLAGS: -Irust/target/release -Irust/target/x86_64-apple-darwin/release

--- a/zk/proofs.go
+++ b/zk/proofs.go
@@ -1,6 +1,3 @@
-//go:build !skiprusttests
-// +build !skiprusttests
-
 // Copyright (c) 2024 The illium developers
 // Use of this source code is governed by an MIT
 // license that can be found in the LICENSE file.
@@ -8,12 +5,6 @@
 package zk
 
 /*
-#cgo linux CFLAGS: -Irust/target/release -Irust-target-release-zk
-#cgo linux LDFLAGS: -Lrust/target/release -Lrust-target-release-zk -l:libillium_zk.a -ldl -lpthread -lgcc_s -lc -lm -lssl -lcrypto -lstdc++
-#cgo windows CFLAGS: -Irust/target/release
-#cgo windows LDFLAGS: -Lrust/target/release -l:libillium_zk.lib
-#cgo darwin CFLAGS: -Irust/target/release -Irust/target/x86_64-apple-darwin/release
-#cgo darwin LDFLAGS: -Lrust/target/release -Lrust/target/x86_64-apple-darwin/release -lillium_zk -lc++ -lssl -lcrypto -framework SystemConfiguration
 #include <stdlib.h>
 #include <stdint.h>
 #include <unistd.h>

--- a/zk/proofs.go
+++ b/zk/proofs.go
@@ -9,7 +9,7 @@ package zk
 
 /*
 #cgo linux CFLAGS: -Irust/target/release -Irust-target-release-zk
-#cgo linux LDFLAGS: -Lrust/target/release -Lrust-target-release-zk -l:libillium_zk.a -ldl -lpthread -lgcc_s -lc -lm -lssl -lcrypto -lstdc++ -L/usr/local/cuda/lib64 -L/usr/local/cuda/targets/x86_64-linux/lib -lcudart
+#cgo linux LDFLAGS: -Lrust/target/release -Lrust-target-release-zk -l:libillium_zk.a -ldl -lpthread -lgcc_s -lc -lm -lssl -lcrypto -lstdc++
 #cgo windows CFLAGS: -Irust/target/release
 #cgo windows LDFLAGS: -Lrust/target/release -l:libillium_zk.lib
 #cgo darwin CFLAGS: -Irust/target/release -Irust/target/x86_64-apple-darwin/release

--- a/zk/rust/Cargo.toml
+++ b/zk/rust/Cargo.toml
@@ -18,9 +18,9 @@ flate2 = "1.0.26"
 hex = "0.4.3"
 itertools = "0.11"
 lazy_static = "1.4.0"
-lurk = { git = "https://github.com/lurk-lab/lurk-rs.git", branch = "main" }
+lurk = { git = "https://github.com/lurk-lab/lurk-rs.git", branch = "main"}
 lurk-macros = "0.2.0"
-nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "arecibo" }
+nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "arecibo", default-features = false}
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 once_cell = "1.19.0"
 openssl = { version = "0.10", features = ["vendored"] }


### PR DESCRIPTION
Background: 
Either lurk-rs or one of its dependencies appear to be looking to see if you have the nvidia-cuda-toolkit installed locally and linking with it regardless of whether you use the cuda rust build feature or not. (This is a possible bug).

If you compile lurk-rs as a standalone app you wont notice that it's doing this, but when you link to the rust binary from Go you need to know if it is or not because you add the cuda build flags to the CGO directives if it is. 

This PR adds a Go build tag (called cuda) that will add the cuda CGO directives if you use the build tag. The Makefile has changed as well. 

If you don't have the nvidia-cuda-toolkit installed:
```
make install
```
If you do:
```
CUDA=1 make install
```

You will get compile errors if you use that ENV variable when you don't have the nvidia-cuda-toolkit installed and vice versa.

Closes #70 