### PR TITLE
Check for used ports and implement IPv6 Multiaddr

### DIFF
--- a/repo/config.go
+++ b/repo/config.go
@@ -209,6 +209,9 @@ func LoadConfig() (*Config, error) {
 	// Default RPC to listen on localhost only.
 	if cfg.RPCOpts.GrpcListener == "" {
 		addrs, err := net.LookupHost("localhost")
+		if err != nil || len(addrs) == 0 {
+			return nil, errors.New("error determining local host for grpc server")
+		}
 		
 		// Default port
 		grpcPort := defaultGrpcPort

--- a/repo/config.go
+++ b/repo/config.go
@@ -209,13 +209,48 @@ func LoadConfig() (*Config, error) {
 	// Default RPC to listen on localhost only.
 	if cfg.RPCOpts.GrpcListener == "" {
 		addrs, err := net.LookupHost("localhost")
-		if err != nil || len(addrs) == 0 {
-			return nil, errors.New("error determining local host for grpc server")
+		
+		// Default port
+		grpcPort := defaultGrpcPort
+
+		// Find an unused port
+		for {    
+			ln, err := net.Listen("tcp", fmt.Sprintf(":%d", grpcPort))
+			if err != nil {
+				grpcPort++
+			} else {
+				ln.Close()
+				break
+			}
 		}
-		ma, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", addrs[0], defaultGrpcPort))
-		if err != nil {
-			return nil, err
+
+		// Check the type of the IP address and format the multiaddress accordingly
+		var ma multiaddr.Multiaddr
+		for _, addr := range addrs {
+			ip := net.ParseIP(addr)
+			if ip != nil {
+				if ip.To4() != nil {
+					// IPv4 address
+					ma, err = multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", ip.String(), grpcPort))
+				} else {
+					// IPv6 address
+					ma, err = multiaddr.NewMultiaddr(fmt.Sprintf("/ip6/%s/tcp/%d", ip.String(), grpcPort))
+				}
+
+				if err != nil {
+					fmt.Println("Error creating multiaddr:", err)
+					continue
+				}
+
+				// Successfully created multiaddr, break out of the loop
+				break
+			}
 		}
+
+		if ma == nil {
+			return nil, errors.New("failed to create multiaddr for any local address")
+		}
+
 		cfg.RPCOpts.GrpcListener = ma.String()
 	}
 


### PR DESCRIPTION
Self-Explanatory. This PR checks for used ports when creating the multiaddr and then increments until an open port is found. If the lookup address is IPv6 then we create a multiaddr in that format instead of assuming it's an IPv4.