### PR TITLE
Evict invalid transactions from mempool after failed block gen

### DIFF
--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -1332,7 +1332,7 @@ func TestValidateBlock(t *testing.T) {
 	for _, test := range tests {
 		blk, err := test.block(proto.Clone(block).(*blocks.Block))
 		assert.NoError(t, err)
-		err = b.validateBlock(blk, test.flags)
+		_, err = b.validateBlock(blk, test.flags)
 		if test.expectedErr == nil {
 			assert.NoErrorf(t, err, "block validation test: %s failure", test.name)
 		} else {

--- a/gen/generate.go
+++ b/gen/generate.go
@@ -272,7 +272,11 @@ func (g *BlockGenerator) generateBlock() error {
 	}
 	blk.Header.Signature = sig
 
-	if err := g.chain.CheckConnectBlock(blk); err != nil {
+	if invalidIdx, err := g.chain.CheckConnectBlock(blk); err != nil {
+		if invalidIdx >= 0 && invalidIdx < len(blk.Transactions) {
+			invalidTx := blk.Transactions[invalidIdx]
+			g.mpool.RemoveBlockTransactions([]*transactions.Transaction{invalidTx})
+		}
 		return err
 	}
 

--- a/server.go
+++ b/server.go
@@ -671,7 +671,7 @@ func (s *Server) setAutostake(autostake bool) error {
 
 func (s *Server) processBlock(blk *blocks.Block, relayingPeer peer.ID, recheck bool) error {
 	<-s.ready
-	err := s.blockchain.CheckConnectBlock(blk)
+	_, err := s.blockchain.CheckConnectBlock(blk)
 
 	switch err.(type) {
 	case blockchain.OrphanBlockError:


### PR DESCRIPTION
If block generator calls `CheckConnectBlock` and it fails because of an invalid transaction, return the index of the transaction in the block so the generator can evict it from the mempool. 

If we do not do this, an invalid transaction getting suck in the mempool somehow can stall the chain until it's purged at the ttl.