### PR TITLE
Set validator coinbase preference based on uptime

### DIFF
--- a/blockchain/validatorset.go
+++ b/blockchain/validatorset.go
@@ -549,10 +549,6 @@ func (vs *ValidatorSet) ConnectBlock(blk *blocks.Block, validatorReward types.Am
 				valNew.UnclaimedCoins = 0
 			}
 
-			if valNew.EpochBlocks < blockProductionFloor(float64(vs.EpochBlocks), expectedBlocks/float64(vs.EpochBlocks)) {
-				valNew.UnclaimedCoins = 0
-			}
-
 			valNew.EpochBlocks = 0
 			valNew.ExpectedBlocks = 0
 			valNew.CoinbasePenalty = false
@@ -801,16 +797,6 @@ func blockProductionLimit(EpochBlocks float64, stakePercentage float64) uint32 {
 		y = 1
 	}
 	return uint32(x + y + .5)
-}
-
-// Six standard deviations from the expected number of blocks.
-func blockProductionFloor(EpochBlocks float64, stakePercentage float64) uint32 {
-	expectedBlocks := uint32(EpochBlocks * stakePercentage)
-	dev := uint32(math.Sqrt(EpochBlocks*stakePercentage*(1-stakePercentage)) * 6)
-	if dev > expectedBlocks {
-		return 0
-	}
-	return (expectedBlocks - dev) / 3
 }
 
 // Returns a value for weight for the given maturity (in months) that approximates what you would get with a typical bond yield curve.

--- a/blockchain/validatorset.go
+++ b/blockchain/validatorset.go
@@ -520,10 +520,6 @@ func (vs *ValidatorSet) ConnectBlock(blk *blocks.Block, validatorReward types.Am
 				copyValidator(valNew, valOld)
 			}
 
-			expectedBlocks := valNew.ExpectedBlocks
-			if expectedBlocks < 1 {
-				expectedBlocks = 1
-			}
 			valTotal := types.Amount(0)
 			for nullifier, stake := range valNew.Nullifiers {
 				timeSinceStake := blockTime.Sub(stake.Blockstamp)

--- a/consensus/chooser_test.go
+++ b/consensus/chooser_test.go
@@ -34,7 +34,7 @@ func TestBackoffChooser(t *testing.T) {
 		chooser.peers[i] = pid
 	}
 
-	bochooser := NewBackoffChooser(chooser)
+	bochooser := NewBackoffChooser(chooser, &MockValConn{})
 
 	for i := 0; i < 100; i++ {
 		assert.NotEqual(t, "", bochooser.WeightedRandomValidator())

--- a/consensus/engine.go
+++ b/consensus/engine.go
@@ -363,7 +363,7 @@ func (eng *ConsensusEngine) handleQuery(req *wire.MsgPollRequest, remotePeer pee
 
 func (eng *ConsensusEngine) handleRequestExpiration(key string, p peer.ID) {
 	eng.chooser.RegisterDialFailure(p)
-	eng.valConn.RegisterQueryFailure(p)
+	eng.valConn.RegisterDialFailure(p)
 	r, ok := eng.queries[key]
 	if !ok {
 		return
@@ -417,7 +417,7 @@ func (eng *ConsensusEngine) queueMessageToPeer(pollReq *wire.MsgPollRequest, pee
 
 func (eng *ConsensusEngine) handleRegisterVotes(p peer.ID, resp *wire.MsgPollResponse) {
 	eng.chooser.RegisterDialSuccess(p)
-	eng.valConn.RegisterQuerySuccess(p)
+	eng.valConn.RegisterDialSuccess(p)
 	key := queryKey(resp.Request_ID, p.String())
 
 	r, ok := eng.queries[key]

--- a/consensus/engine.go
+++ b/consensus/engine.go
@@ -363,6 +363,7 @@ func (eng *ConsensusEngine) handleQuery(req *wire.MsgPollRequest, remotePeer pee
 
 func (eng *ConsensusEngine) handleRequestExpiration(key string, p peer.ID) {
 	eng.chooser.RegisterDialFailure(p)
+	eng.valConn.RegisterQueryFailure(p)
 	r, ok := eng.queries[key]
 	if !ok {
 		return
@@ -416,6 +417,7 @@ func (eng *ConsensusEngine) queueMessageToPeer(pollReq *wire.MsgPollRequest, pee
 
 func (eng *ConsensusEngine) handleRegisterVotes(p peer.ID, resp *wire.MsgPollResponse) {
 	eng.chooser.RegisterDialSuccess(p)
+	eng.valConn.RegisterQuerySuccess(p)
 	key := queryKey(resp.Request_ID, p.String())
 
 	r, ok := eng.queries[key]

--- a/consensus/engine_test.go
+++ b/consensus/engine_test.go
@@ -44,6 +44,8 @@ type MockValConn struct{}
 func (m *MockValConn) ConnectedStakePercentage() float64 {
 	return 100
 }
+func (m *MockValConn) RegisterDialSuccess(p peer.ID) {}
+func (m *MockValConn) RegisterDialFailure(p peer.ID) {}
 
 type mockNode struct {
 	engine *ConsensusEngine

--- a/consensus/valconn.go
+++ b/consensus/valconn.go
@@ -8,6 +8,6 @@ import "github.com/libp2p/go-libp2p/core/peer"
 
 type ValidatorSetConnection interface {
 	ConnectedStakePercentage() float64
-	RegisterQuerySuccess(p peer.ID)
-	RegisterQueryFailure(p peer.ID)
+	RegisterDialSuccess(p peer.ID)
+	RegisterDialFailure(p peer.ID)
 }

--- a/consensus/valconn.go
+++ b/consensus/valconn.go
@@ -4,6 +4,10 @@
 
 package consensus
 
+import "github.com/libp2p/go-libp2p/core/peer"
+
 type ValidatorSetConnection interface {
 	ConnectedStakePercentage() float64
+	RegisterQuerySuccess(p peer.ID)
+	RegisterQueryFailure(p peer.ID)
 }

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/nixberg/chacha-rng-go v0.1.0
 	github.com/project-illium/logger v0.0.0-20240118200101-2fb0847599c9
-	github.com/project-illium/walletlib v0.0.0-20240219154023-12befb3ecd20
+	github.com/project-illium/walletlib v0.0.0-20240220013424-f81d7bdc3de6
 	github.com/project-illium/weightedrand/v2 v2.1.0
 	github.com/pterm/pterm v0.12.75
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -660,6 +660,10 @@ github.com/project-illium/walletlib v0.0.0-20240215010012-88f813ced3b7 h1:V5r42N
 github.com/project-illium/walletlib v0.0.0-20240215010012-88f813ced3b7/go.mod h1:SaPFuaIbXpp+aQMsImjpLac3B1EOrtrc8bpNYS9bzXY=
 github.com/project-illium/walletlib v0.0.0-20240219154023-12befb3ecd20 h1:V1nS0Z6XcG49W4Djfg8EpciisSyCCyy9wzLdZQMsIvY=
 github.com/project-illium/walletlib v0.0.0-20240219154023-12befb3ecd20/go.mod h1:SaPFuaIbXpp+aQMsImjpLac3B1EOrtrc8bpNYS9bzXY=
+github.com/project-illium/walletlib v0.0.0-20240220005353-f995612b6538 h1:steeoU3M/J1n9LRM0rQ3Bx/F9juG5b/Oo4G4cQYMSc0=
+github.com/project-illium/walletlib v0.0.0-20240220005353-f995612b6538/go.mod h1:SaPFuaIbXpp+aQMsImjpLac3B1EOrtrc8bpNYS9bzXY=
+github.com/project-illium/walletlib v0.0.0-20240220013424-f81d7bdc3de6 h1:35t3LDCvFdvLiJpmdKQJDkf+notZlSQg7t9oFzuyoL4=
+github.com/project-illium/walletlib v0.0.0-20240220013424-f81d7bdc3de6/go.mod h1:SaPFuaIbXpp+aQMsImjpLac3B1EOrtrc8bpNYS9bzXY=
 github.com/project-illium/weightedrand/v2 v2.1.0 h1:8zVDjthKwP0yfHt3uC3fTEqH0KJ5AwCL02YYx+cpdb8=
 github.com/project-illium/weightedrand/v2 v2.1.0/go.mod h1:/AeYfjb6TF9oSmsWXWZQ6H2+5NAQB6zdcCJbhDZxAd0=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/mempool/errors.go
+++ b/mempool/errors.go
@@ -32,6 +32,7 @@ const (
 	ErrMinStake
 	ErrDuplicateCoinbase
 	ErrTreasuryWhitelist
+	ErrPoorValidatorUptime
 )
 
 var (
@@ -41,10 +42,11 @@ var (
 
 // Map of ErrorCode values back to their constant names for pretty printing.
 var errorCodeStrings = map[ErrorCode]string{
-	ErrFeeTooLow:         "ErrFeeTooLow",
-	ErrMinStake:          "ErrMinStake",
-	ErrDuplicateCoinbase: "ErrDuplicateCoinbase",
-	ErrTreasuryWhitelist: "ErrTreasuryWhitelist",
+	ErrFeeTooLow:           "ErrFeeTooLow",
+	ErrMinStake:            "ErrMinStake",
+	ErrDuplicateCoinbase:   "ErrDuplicateCoinbase",
+	ErrTreasuryWhitelist:   "ErrTreasuryWhitelist",
+	ErrPoorValidatorUptime: "ErrPoorValidatorUptime",
 }
 
 // String returns the ErrorCode as a human-readable name.

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -325,6 +325,10 @@ func (m *Mempool) processTransaction(tx *transactions.Transaction) error {
 			return ruleError(blockchain.ErrInvalidTx, "coinbase transaction creates invalid number of coins")
 		}
 
+		if !m.cfg.policy.GetValidatorAcceptableCoinbase(validatorID) {
+			return policyError(ErrPoorValidatorUptime, "coinbase for peer with poor uptime")
+		}
+
 		// There is an unlikely scenario where a coinbase could sit in the mempool
 		// for an entire epoch and not get included in a block. We don't want two
 		// coinbases from the same validator in the mempool so we will evict the

--- a/net/validator_connector.go
+++ b/net/validator_connector.go
@@ -72,9 +72,9 @@ func (vc *ValidatorConnector) ConnectedStakePercentage() float64 {
 	return vc.connectedPercentage
 }
 
-// RegisterQuerySuccess registers a successful query for the purpose of
+// RegisterDialSuccess registers a successful query for the purpose of
 // tracking validator uptime and behavior.
-func (vc *ValidatorConnector) RegisterQuerySuccess(p peer.ID) {
+func (vc *ValidatorConnector) RegisterDialSuccess(p peer.ID) {
 	vc.mtx.Lock()
 	defer vc.mtx.Unlock()
 
@@ -88,9 +88,9 @@ func (vc *ValidatorConnector) RegisterQuerySuccess(p peer.ID) {
 	}
 }
 
-// RegisterQueryFailure registers a failed query for the purpose of
+// RegisterDialFailure registers a failed query for the purpose of
 // tracking validator uptime and behavior.
-func (vc *ValidatorConnector) RegisterQueryFailure(p peer.ID) {
+func (vc *ValidatorConnector) RegisterDialFailure(p peer.ID) {
 	vc.mtx.Lock()
 	defer vc.mtx.Unlock()
 
@@ -106,9 +106,9 @@ func (vc *ValidatorConnector) RegisterQueryFailure(p peer.ID) {
 	}
 }
 
-// ValidatorQueryRate returns the query success rate for the validator
+// ValidatorDialSuccessRate returns the dial success rate for the validator
 // for the prior epoch.
-func (vc *ValidatorConnector) ValidatorQueryRate(p peer.ID) float64 {
+func (vc *ValidatorConnector) ValidatorDialSuccessRate(p peer.ID) float64 {
 	vc.mtx.RLock()
 	defer vc.mtx.RUnlock()
 

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/query"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/project-illium/ilxd/repo"
 	"github.com/project-illium/ilxd/types"
 	"github.com/project-illium/ilxd/types/blocks"
@@ -17,16 +18,27 @@ import (
 	"sync"
 )
 
+// minQuerySuccessRate defines the minimum query success rate
+// for validators before we start marking their coinbases as
+// not preferred.
+const minQuerySuccessRate = .5
+
+// Policy tracks the current state of the local node policy.
+// This is used to determine whether to vote for blocks in
+// the consensus engine.
 type Policy struct {
 	ds                 repo.Datastore
 	minFeePerKilobyte  types.Amount
 	minStake           types.Amount
 	blocksizeSoftLimit uint32
 	treasuryWhitelist  []types.ID
+	validatorStatFunc  func(p peer.ID) float64
 
 	mtx sync.RWMutex
 }
 
+// NewPolicy returns a new Policy. The datastore can be nil if you don't wish to
+// persist the treasury whitelist to disk.
 func NewPolicy(ds repo.Datastore, minFeePerKilobyte, minStake types.Amount, blocksizeSoftLimit uint32) (*Policy, error) {
 	var treasuryWhitelist []types.ID
 	if ds != nil {
@@ -59,6 +71,7 @@ func NewPolicy(ds repo.Datastore, minFeePerKilobyte, minStake types.Amount, bloc
 	}, nil
 }
 
+// GetMinFeePerKilobyte returns the minimum fee per kilobyte
 func (p *Policy) GetMinFeePerKilobyte() types.Amount {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
@@ -66,6 +79,7 @@ func (p *Policy) GetMinFeePerKilobyte() types.Amount {
 	return p.minFeePerKilobyte
 }
 
+// SetMinFeePerKilobyte sets the minimum fee per kilobyte
 func (p *Policy) SetMinFeePerKilobyte(fpkb types.Amount) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
@@ -73,6 +87,7 @@ func (p *Policy) SetMinFeePerKilobyte(fpkb types.Amount) {
 	p.minFeePerKilobyte = fpkb
 }
 
+// GetMinStake returns the minimum stake amount
 func (p *Policy) GetMinStake() types.Amount {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
@@ -80,6 +95,7 @@ func (p *Policy) GetMinStake() types.Amount {
 	return p.minStake
 }
 
+// SetMinStake sets the minimum stake amount
 func (p *Policy) SetMinStake(amt types.Amount) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
@@ -87,6 +103,7 @@ func (p *Policy) SetMinStake(amt types.Amount) {
 	p.minStake = amt
 }
 
+// GetBlocksizeSoftLimit returns the blocksize soft limit
 func (p *Policy) GetBlocksizeSoftLimit() uint32 {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
@@ -94,6 +111,7 @@ func (p *Policy) GetBlocksizeSoftLimit() uint32 {
 	return p.blocksizeSoftLimit
 }
 
+// SetBlocksizeSoftLimit sets the blocksize soft limit
 func (p *Policy) SetBlocksizeSoftLimit(limit uint32) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
@@ -101,6 +119,7 @@ func (p *Policy) SetBlocksizeSoftLimit(limit uint32) {
 	p.blocksizeSoftLimit = limit
 }
 
+// GetTreasuryWhitelist returns the current treasury whitelist
 func (p *Policy) GetTreasuryWhitelist() []types.ID {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
@@ -112,6 +131,8 @@ func (p *Policy) GetTreasuryWhitelist() []types.ID {
 	return ret
 }
 
+// AddToTreasuryWhitelist adds a txid to the treasury whitelist.
+// This also persists it to the database.
 func (p *Policy) AddToTreasuryWhitelist(txids ...types.ID) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
@@ -127,6 +148,8 @@ func (p *Policy) AddToTreasuryWhitelist(txids ...types.ID) {
 	p.treasuryWhitelist = append(p.treasuryWhitelist, txids...)
 }
 
+// RemoveFromTreasuryWhitelist removes a txid from the treasury whitelist.
+// This also updates the database.
 func (p *Policy) RemoveFromTreasuryWhitelist(txids ...types.ID) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
@@ -147,6 +170,22 @@ loop:
 	}
 }
 
+// SetValidatorStatFunc sets a function to be used to get the validator connection
+// stats.
+func (p *Policy) SetValidatorStatFunc(f func(p peer.ID) float64) {
+	p.validatorStatFunc = f
+}
+
+// GetValidatorAcceptableCoinbase returns whether a validator's coinbase is
+// considered acceptable based on the validator's uptime.
+func (p *Policy) GetValidatorAcceptableCoinbase(pid peer.ID) bool {
+	if p.validatorStatFunc != nil {
+		return p.validatorStatFunc(pid) >= minQuerySuccessRate
+	}
+	return true
+}
+
+// IsAcceptableBlock returns whether the block matches our policy preferences
 func (p *Policy) IsAcceptableBlock(blk *blocks.Block) (bool, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
@@ -183,11 +222,24 @@ func (p *Policy) IsAcceptableBlock(blk *blocks.Block) (bool, error) {
 			if types.Amount(typ.StakeTransaction.Amount) < p.minStake {
 				return false, nil
 			}
+		case *transactions.Transaction_CoinbaseTransaction:
+			if p.validatorStatFunc != nil {
+				peerID, err := peer.IDFromBytes(typ.CoinbaseTransaction.Validator_ID)
+				if err != nil {
+					return false, nil
+				}
+				if p.validatorStatFunc(peerID) < minQuerySuccessRate {
+					return false, nil
+				}
+			}
 		}
 	}
 	return true, nil
 }
 
+// CalcFeePerKilobyte computes and returns the fee per kilobyte for the transaction.
+//
+// Only standard and mint transactions have fees. All others return 0 without error.
 func CalcFeePerKilobyte(tx *transactions.Transaction) (types.Amount, bool, error) {
 	var fee uint64
 	switch t := tx.GetTx().(type) {

--- a/server.go
+++ b/server.go
@@ -367,7 +367,7 @@ func BuildServer(config *repo.Config) (*Server, error) {
 	}
 
 	valConn := net.NewValidatorConnector(network.Host(), hostID, chain.GetValidator, chain.Validators, chain.Subscribe)
-	policy.SetValidatorStatFunc(valConn.ValidatorQueryRate)
+	policy.SetValidatorStatFunc(valConn.ValidatorDialSuccessRate)
 
 	engine, err := consensus.NewConsensusEngine(ctx, []consensus.Option{
 		consensus.Params(netParams),

--- a/server.go
+++ b/server.go
@@ -367,6 +367,7 @@ func BuildServer(config *repo.Config) (*Server, error) {
 	}
 
 	valConn := net.NewValidatorConnector(network.Host(), hostID, chain.GetValidator, chain.Validators, chain.Subscribe)
+	policy.SetValidatorStatFunc(valConn.ValidatorQueryRate)
 
 	engine, err := consensus.NewConsensusEngine(ctx, []consensus.Option{
 		consensus.Params(netParams),


### PR DESCRIPTION
This is a big change to how we handle inactive validators. 

Previously, a validator would lose their coinbase if the number of blocks they produced in the epoch fell below some minimum floor. 

This proves to be a bad approach for two reasons:
- If a validator changes their local policy (for example by lowering their fee-per-kb or increasing their blocksize limit) their blocks will be rejected if the majority don't follow the same policy. This would cause the validator to fall below the floor, lose their reward, and likely strongly disincentivize being the first mover when changing the policy. Likely this would freeze the policy in place and make it hard to change. 

- It's possible for malicious validators to produce more than their share of blocks, but only up to a limit. If enough do this, some validators could get squeezed and be pushed under the floor and lose their coinbase due to no fault of their own. 

So this PR removes the block production floor. 

However, we need another way to disincetivize poor validator behavior. The way this PR addresses it is by tracking the responsiveness of each validator in the consensus engine. If their responsiveness drops below a threshold we treat their coinbases as `Not Preferred`. 

This means they will be rejected from the mempool, and if a block is produced cointaining their coinbase the node will vote `Not Preferred` for it. If a majority vote `Not Preferred` the block cointaining the coinbase will not finalize. 

If it does finalize we will still accept it.

