### PR TITLE
docs: fix running_a_node link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ CUDA=1 make install
 ```
 
 ### Usage
-Vist [docs.illium.org](https://docs.illium.org/docs/node/running_a_node) for a comprehensive guide to running a node.
+Vist [docs.illium.org](https://docs.illium.org/node) for a comprehensive guide to running a node.
 
 ### Contributing
 We'd love your help! See the [contributing guidlines](https://github.com/project-illium/ilxd/blob/master/CONTRIBUTING.md) before submitting your first PR.


### PR DESCRIPTION
previous link (https://docs.illium.org/docs/node/running_a_node) has been removed, but https://docs.illium.org/node has a heading of "Running a node"