### PR TITLE
Batch block processing during IDB

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -28,3 +28,5 @@ issues:
     - ".print` is unused"
     - "func `generateBlocksDat` is unused"
     - "copylocks: call of json.MarshalIndent copies lock value: github.com/project-illium/ilxd/rpc/pb.RawTransaction contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex"
+    - "Error return value of `proofVal.Validate` is not checked"
+    - "Error return value of `sigVal.Validate` is not checked"

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,9 @@ protos:
 
 install:
 ifdef CUDA
-	@$(MAKE) build ARGS="-tags=cuda -o $(GOPATH)/bin/ilxd"
-	cd cli && go build -tags=cuda -o $(GOPATH)/bin/ilxcli
+	@$(MAKE) build ARGS="-tags=cuda -o $(GOPATH)/bin/"
 else
-	@$(MAKE) build ARGS="-o $(GOPATH)/bin/ilxd"
-	cd cli && go build -o $(GOPATH)/bin/ilxcli
+	@$(MAKE) build ARGS="-o $(GOPATH)/bin/"
 endif
 
 build: rust-bindings go
@@ -22,11 +20,11 @@ build: rust-bindings go
 .PHONY: go
 go:
 ifdef CUDA
-	go build -tags=cuda $(ARGS)
-	cd cli && go build -tags=cuda $(ARGS)
+	go build -tags=cuda $(ARGS)ilxd
+	cd cli && go build -tags=cuda $(ARGS)ilxcli
 else
-	go build $(ARGS)
-	cd cli && go build $(ARGS)
+	go build $(ARGS)ilxd
+	cd cli && go build $(ARGS)ilxcli
 endif
 
 .PHONY: rust-bindings

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,13 @@ protos:
 	protoc -I=rpc -I=types/transactions -I=types/blocks --go_out=rpc/pb --go-grpc_out=rpc/pb --go_opt=paths=source_relative,Mtransactions.proto=github.com/project-illium/ilxd/types/transactions,Mblocks.proto=github.com/project-illium/ilxd/types/blocks --go-grpc_opt=paths=source_relative rpc/ilxrpc.proto
 	protoc -I=blockchain/indexers/pb --go_out=blockchain/indexers/pb blockchain/indexers/pb/db_indexer_models.proto
 
-install:
+install: rust-bindings
 ifdef CUDA
-	@$(MAKE) build ARGS="-tags=cuda -o $(GOPATH)/bin/"
+	go build -tags=cuda -o $(GOPATH)/bin/ilxd
+	cd cli && go build -tags=cuda -o $(GOPATH)/bin/ilxcli
 else
-	@$(MAKE) build ARGS="-o $(GOPATH)/bin/"
+	go build -o $(GOPATH)/bin/ilxd
+	cd cli && go build -o $(GOPATH)/bin/ilxcli
 endif
 
 build: rust-bindings go
@@ -20,11 +22,11 @@ build: rust-bindings go
 .PHONY: go
 go:
 ifdef CUDA
-	go build -tags=cuda $(ARGS)ilxd
-	cd cli && go build -tags=cuda $(ARGS)ilxcli
+	go build -tags=cuda $(ARGS)
+	cd cli && go build -tags=cuda $(ARGS)
 else
-	go build $(ARGS)ilxd
-	cd cli && go build $(ARGS)ilxcli
+	go build $(ARGS)
+	cd cli && go build $(ARGS)
 endif
 
 .PHONY: rust-bindings

--- a/blockchain/batch.go
+++ b/blockchain/batch.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2024 The illium developers
+// Use of this source code is governed by an MIT
+// license that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"github.com/project-illium/ilxd/types/blocks"
+	"sync"
+)
+
+type Batch struct {
+	chain *Blockchain
+	blks  []*blocks.Block
+	opts  int
+	size  int
+	wg    sync.WaitGroup
+}
+
+func (b *Batch) AddBlock(blk *blocks.Block) error {
+	proofVal := NewProofValidator(b.chain.proofCache, b.chain.verifier)
+	sigVal := NewSigValidator(b.chain.sigCache)
+
+	b.wg.Add(len(blk.Transactions) * 2)
+
+	go func() {
+		proofVal.Validate(blk.Transactions)
+		b.wg.Done()
+	}()
+	go func() {
+		sigVal.Validate(blk.Transactions)
+		b.wg.Done()
+	}()
+
+	ops, size, err := datastoreTxnLimits(blk, bannedNullifiers)
+	if err != nil {
+		return err
+	}
+	b.opts += ops
+	b.size += size
+	b.blks = append(b.blks, blk)
+	return nil
+}
+
+func (b *Batch) Commit() error {
+	b.wg.Wait()
+	
+	return nil
+}

--- a/blockchain/batch.go
+++ b/blockchain/batch.go
@@ -5,18 +5,35 @@
 package blockchain
 
 import (
+	"context"
+	"errors"
 	"github.com/project-illium/ilxd/types/blocks"
 	"sync"
 )
 
+// ErrMaxBatchSize is an error that means the batch exceeds the database limits
+var ErrMaxBatchSize = errors.New("batch exceeds max batch size")
+
+// Batch represents a batch of blocks that can be connected to the chain
+// using only a single database transaction. This is faster than opening
+// a new transaction for each individual block.
+//
+// This is used primarily during IBD.
 type Batch struct {
-	chain *Blockchain
-	blks  []*blocks.Block
-	opts  int
-	size  int
-	wg    sync.WaitGroup
+	chain     *Blockchain
+	blks      []*blocks.Block
+	ops       int
+	size      int
+	wg        sync.WaitGroup
+	committed bool
 }
 
+// AddBlock adds a block to the batch. It will be added to the chain
+// when commit is called.
+//
+// If the block would put the batch over the maximum ops or size limit
+// for a database transaction an ErrMaxBatchSize is returned and the
+// block is not added to the batch.
 func (b *Batch) AddBlock(blk *blocks.Block) error {
 	proofVal := NewProofValidator(b.chain.proofCache, b.chain.verifier)
 	sigVal := NewSigValidator(b.chain.sigCache)
@@ -32,18 +49,66 @@ func (b *Batch) AddBlock(blk *blocks.Block) error {
 		b.wg.Done()
 	}()
 
-	ops, size, err := datastoreTxnLimits(blk, bannedNullifiers)
+	ops, size, err := datastoreTxnLimits(blk, 10)
 	if err != nil {
 		return err
 	}
-	b.opts += ops
+	if b.ops+ops > dsMaxBatchCount || b.size+size > dsMaxBatchSize {
+		return ErrMaxBatchSize
+	}
+	b.ops += ops
 	b.size += size
 	b.blks = append(b.blks, blk)
 	return nil
 }
 
-func (b *Batch) Commit() error {
+// Discard discards the current batch without committing anything
+func (b *Batch) Discard() {
+	if !b.committed {
+		b.committed = true
+		b.chain.stateLock.Unlock()
+	}
+}
+
+// Commit will commit the batch to disk.
+//
+// Note this function is not fully atomic. To make it such we would need
+// rollback ability on the validator set, nullifier set, accumulator db, txoroot db,
+// and index (and possibly others).
+//
+// As it stands, we validate a block first. If it fails validation we commit all the prior
+// blocks and return an error.
+//
+// If the database commit fails (which really should not happen), then the validator set
+// and others could be left in a bad state.
+func (b *Batch) Commit(flags BehaviorFlags) error {
+	if b.committed {
+		return errors.New("batch was discarded")
+	}
+	b.committed = true
+	defer b.chain.stateLock.Unlock()
+
 	b.wg.Wait()
-	
-	return nil
+
+	dbtx, err := b.chain.ds.NewTransaction(context.Background(), false)
+	if err != nil {
+		return err
+	}
+	flags = flags | BFBatchCommit | BFNoValidation
+
+	defer dbtx.Discard(context.Background())
+	for _, blk := range b.blks {
+		if _, err := b.chain.validateBlock(blk, flags); err != nil {
+			if err := dbtx.Commit(context.Background()); err != nil {
+				return err
+			}
+			return err
+		}
+		err = b.chain.connectBlock(dbtx, blk, flags)
+		if err != nil {
+			return err
+		}
+	}
+
+	return dbtx.Commit(context.Background())
 }

--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -261,13 +261,6 @@ func (bi *blockIndex) GetNodeByID(blockID types.ID) (*blockNode, error) {
 	return node, nil
 }
 
-// Clone returns a copy of the block index
-func (bi *blockIndex) Clone() *blockIndex {
-	idx := NewBlockIndex(bi.ds)
-	idx.tip = bi.tip
-	return idx
-}
-
 func (bi *blockIndex) limitCache() {
 	if len(bi.cacheByID) > blockIndexCacheSize {
 		for id, node := range bi.cacheByID {

--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -261,6 +261,13 @@ func (bi *blockIndex) GetNodeByID(blockID types.ID) (*blockNode, error) {
 	return node, nil
 }
 
+// Clone returns a copy of the block index
+func (bi *blockIndex) Clone() *blockIndex {
+	idx := NewBlockIndex(bi.ds)
+	idx.tip = bi.tip
+	return idx
+}
+
 func (bi *blockIndex) limitCache() {
 	if len(bi.cacheByID) > blockIndexCacheSize {
 		for id, node := range bi.cacheByID {

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -166,6 +166,18 @@ func NewBlockchain(opts ...Option) (*Blockchain, error) {
 	return b, nil
 }
 
+// BlockBatch returns a new Batch
+func (b *Blockchain) BlockBatch() *Batch {
+	b.stateLock.Lock()
+	return &Batch{
+		chain: b,
+		blks:  nil,
+		ops:   0,
+		size:  0,
+		wg:    sync.WaitGroup{},
+	}
+}
+
 // Close flushes all caches to disk and makes the node safe to shutdown.
 func (b *Blockchain) Close() error {
 	b.stateLock.Lock()
@@ -232,10 +244,16 @@ func (b *Blockchain) ConnectBlock(blk *blocks.Block, flags BehaviorFlags) (err e
 	b.stateLock.Lock()
 	defer b.stateLock.Unlock()
 
-	return b.connectBlock(blk, flags)
+	dbtx, err := b.ds.NewTransaction(context.Background(), false)
+	if err != nil {
+		return err
+	}
+	defer dbtx.Discard(context.Background())
+
+	return b.connectBlock(dbtx, blk, flags)
 }
 
-func (b *Blockchain) connectBlock(blk *blocks.Block, flags BehaviorFlags) (err error) {
+func (b *Blockchain) connectBlock(dbtx datastore.Txn, blk *blocks.Block, flags BehaviorFlags) (err error) {
 	if !flags.HasFlag(BFGenesisValidation) {
 		if err := b.checkBlockContext(blk.Header); err != nil {
 			return err
@@ -257,12 +275,6 @@ func (b *Blockchain) connectBlock(blk *blocks.Block, flags BehaviorFlags) (err e
 			return err
 		}
 	}
-
-	dbtx, err := b.ds.NewTransaction(context.Background(), false)
-	if err != nil {
-		return err
-	}
-	defer dbtx.Discard(context.Background())
 
 	if err := dsPutBlock(dbtx, blk); err != nil {
 		return err
@@ -365,9 +377,12 @@ func (b *Blockchain) connectBlock(blk *blocks.Block, flags BehaviorFlags) (err e
 		return err
 	}
 
-	if err := dbtx.Commit(context.Background()); err != nil {
-		return err
+	if !flags.HasFlag(BFBatchCommit) {
+		if err := dbtx.Commit(context.Background()); err != nil {
+			return err
+		}
 	}
+
 	// Now that we know the disk updated correctly we can update the cache. Ideally this would
 	// be done in a commit hook, but that's a bigger change to the db interface.
 	if blockContainsOutputs {
@@ -452,6 +467,16 @@ func (b *Blockchain) ReindexChainState() error {
 	}
 
 	i := uint32(0)
+	dbtx, err = b.ds.NewTransaction(context.Background(), false)
+	if err != nil {
+		return err
+	}
+
+	var (
+		ops  = 0
+		size = 0
+	)
+
 	for {
 		blockID, err := dsFetchBlockIDFromHeight(b.ds, i)
 		if errors.Is(err, datastore.ErrNotFound) {
@@ -464,15 +489,47 @@ func (b *Blockchain) ReindexChainState() error {
 		if err != nil {
 			return err
 		}
-
-		flags := BFNoDupBlockCheck | BFFastAdd | BFNoNotification
-		if i == 0 {
-			flags = BFNoDupBlockCheck | BFFastAdd | BFGenesisValidation
+		bannedNullifiers, err := b.validatorSet.ComputeBannedNullifiers(blk)
+		if err != nil {
+			return err
 		}
-		if err := b.connectBlock(blk, flags); err != nil {
+
+		o, s, err := datastoreTxnLimits(blk, bannedNullifiers)
+		if err != nil {
+			return err
+		}
+		ops += o
+		size += s
+
+		if ops > dsMaxBatchCount || size > dsMaxBatchSize {
+			if err := dbtx.Commit(context.Background()); err != nil {
+				return err
+			}
+			dbtx, err = b.ds.NewTransaction(context.Background(), false)
+			if err != nil {
+				return err
+			}
+			ops = 0
+			size = 0
+		}
+
+		flags := BFNoDupBlockCheck | BFFastAdd | BFNoNotification | BFNoValidation | BFBatchCommit
+		if i == 0 {
+			flags = BFNoDupBlockCheck | BFFastAdd | BFGenesisValidation | BFNoValidation | BFBatchCommit
+		}
+		if _, err := b.validateBlock(blk, flags); err != nil {
+			if err := dbtx.Commit(context.Background()); err != nil {
+				return err
+			}
+			return err
+		}
+		if err := b.connectBlock(dbtx, blk, flags); err != nil {
 			return err
 		}
 		i++
+	}
+	if err := dbtx.Commit(context.Background()); err != nil {
+		return err
 	}
 	log.Info("Finished reindex")
 	return nil

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -170,11 +170,11 @@ func NewBlockchain(opts ...Option) (*Blockchain, error) {
 func (b *Blockchain) BlockBatch() *Batch {
 	b.stateLock.Lock()
 	return &Batch{
-		chain: b,
-		blks:  nil,
-		ops:   0,
-		size:  0,
-		wg:    sync.WaitGroup{},
+		chain:    b,
+		blks:     nil,
+		ops:      0,
+		size:     0,
+		blockWGs: make(map[types.ID]*sync.WaitGroup),
 	}
 }
 

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -318,14 +318,11 @@ func (b *Blockchain) connectBlock(dbtx datastore.Txn, blk *blocks.Block, flags B
 			return err
 		}
 	} else {
-		prevHeader, err := b.index.Tip().Header()
-		if err != nil {
-			return err
+
+		if b.params.Name == params.RegestParams.Name && b.index.Tip().Height() == 0 {
+			b.index.tip.timestamp = time.Now().Unix()
 		}
-		if b.params.Name == params.RegestParams.Name && prevHeader.Height == 0 {
-			prevHeader.Timestamp = time.Now().Unix()
-		}
-		prevEpoch := (prevHeader.Timestamp - b.params.GenesisBlock.Header.Timestamp) / b.params.EpochLength
+		prevEpoch := (b.index.Tip().Timestamp() - b.params.GenesisBlock.Header.Timestamp) / b.params.EpochLength
 		blkEpoch := (blk.Header.Timestamp - b.params.GenesisBlock.Header.Timestamp) / b.params.EpochLength
 		if blkEpoch > prevEpoch {
 			coinbase := calculateNextCoinbaseDistribution(b.params, blkEpoch)

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -62,6 +62,10 @@ const (
 	// BFNoFlush skips flushing memory caches to disk.
 	BFNoFlush
 
+	// BFBatchCommit skips the database commit and allows committing
+	// as a batch.
+	BFBatchCommit
+
 	// BFNone is a convenience value to specifically indicate no flags.
 	BFNone BehaviorFlags = 0
 )

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -91,11 +91,8 @@ func (b *Blockchain) checkBlockContext(header *blocks.BlockHeader) error {
 	if types.NewID(header.Parent) != tip.ID() {
 		return ruleError(ErrDoesNotConnect, "block parent does not extend tip")
 	}
-	prevHeader, err := tip.Header()
-	if err != nil {
-		return err
-	}
-	if header.Timestamp <= prevHeader.Timestamp {
+
+	if header.Timestamp <= tip.Timestamp() {
 		return ruleError(ErrInvalidTimestamp, "timestamp is too early")
 	}
 	// The block timestamp is not allowed to be too far ahead of our local clock.

--- a/sync/sync_manager.go
+++ b/sync/sync_manager.go
@@ -619,11 +619,35 @@ func (sm *SyncManager) syncBlocks(p peer.ID, fromHeight, toHeight uint32, parent
 	}
 
 	var (
-		start     = headers[0].Height
-		endHeight = headers[len(headers)-1].Height
-		headerIdx = 0
+		start       = headers[0].Height
+		endHeight   = headers[len(headers)-1].Height
+		headerIdx   = 0
+		processChan = make(chan *blocks.Block, maxBatchSize)
+		errChan     = make(chan error)
 	)
 
+	go func() {
+		batch := sm.chain.BlockBatch()
+		defer batch.Discard()
+
+		for blk := range processChan {
+			if err := batch.AddBlock(blk); errors.Is(err, blockchain.ErrMaxBatchSize) {
+				if err := batch.Commit(flags); err != nil {
+					errChan <- fmt.Errorf("error committing block batch from peer %s. Err: %s", p, err)
+					return
+				}
+
+			}
+		}
+
+		if err := batch.Commit(flags); err != nil {
+			errChan <- fmt.Errorf("error committing block batch from peer %s. Err: %s", p, err)
+			return
+		}
+		close(errChan)
+	}()
+
+blockLoop:
 	for {
 		txsChan, err := sm.chainService.GetBlockTxsStream(p, start, noProofs)
 		if err != nil {
@@ -648,23 +672,22 @@ func (sm *SyncManager) syncBlocks(p peer.ID, fromHeight, toHeight uint32, parent
 				}
 			}
 
-			blk := &blocks.Block{
+			processChan <- &blocks.Block{
 				Header:       headers[headerIdx],
 				Transactions: txs.Transactions,
 			}
 
-			if err := sm.chain.ConnectBlock(blk, flags); err != nil {
-				return fmt.Errorf("error committing block from peer %s. Height: %d, Err: %s", p, blk.Header.Height, err)
-			}
-
 			if headers[headerIdx].Height == endHeight {
-				return nil
+				close(processChan)
+				break blockLoop
 			}
 
 			headerIdx++
 			start = headers[headerIdx].Height
 		}
 	}
+	err = <-errChan
+	return err
 }
 
 func (sm *SyncManager) findForkPoint(currentHeight, toHeight uint32, blockMap map[types.ID]peer.ID) (types.ID, uint32, error) {

--- a/sync/sync_manager.go
+++ b/sync/sync_manager.go
@@ -636,7 +636,7 @@ func (sm *SyncManager) syncBlocks(p peer.ID, fromHeight, toHeight uint32, parent
 					errChan <- fmt.Errorf("error committing block batch: %s", err)
 					return
 				}
-
+				batch = sm.chain.BlockBatch()
 			}
 		}
 

--- a/sync/sync_manager.go
+++ b/sync/sync_manager.go
@@ -633,7 +633,7 @@ func (sm *SyncManager) syncBlocks(p peer.ID, fromHeight, toHeight uint32, parent
 		for blk := range processChan {
 			if err := batch.AddBlock(blk); errors.Is(err, blockchain.ErrMaxBatchSize) {
 				if err := batch.Commit(flags); err != nil {
-					errChan <- fmt.Errorf("error committing block batch from peer %s. Err: %s", p, err)
+					errChan <- fmt.Errorf("error committing block batch: %s", err)
 					return
 				}
 
@@ -641,7 +641,7 @@ func (sm *SyncManager) syncBlocks(p peer.ID, fromHeight, toHeight uint32, parent
 		}
 
 		if err := batch.Commit(flags); err != nil {
-			errChan <- fmt.Errorf("error committing block batch from peer %s. Err: %s", p, err)
+			errChan <- fmt.Errorf("error committing block batch: %s", err)
 			return
 		}
 		close(errChan)

--- a/sync/sync_manager_test.go
+++ b/sync/sync_manager_test.go
@@ -312,7 +312,7 @@ func TestSync(t *testing.T) {
 		}()
 		select {
 		case <-ch:
-		case <-time.After(time.Second * 30):
+		case <-time.After(time.Second * 60):
 			t.Fatal("sync timed out")
 		}
 

--- a/types/transactions/transactions.pb.go
+++ b/types/transactions/transactions.pb.go
@@ -82,9 +82,9 @@ type Transaction struct {
 	//	*Transaction_StakeTransaction
 	//	*Transaction_TreasuryTransaction
 	//	*Transaction_MintTransaction
-	Tx isTransaction_Tx `protobuf_oneof:"Tx"`
+	Tx         isTransaction_Tx `protobuf_oneof:"Tx"`
 	cachedTxid []byte
-	cachedWid []byte
+	cachedWid  []byte
 }
 
 func (x *Transaction) Reset() {


### PR DESCRIPTION
This PR refactors the block processing in the sync manager and the chain so that blocks can be commit in batches using a single database transaction per batch rather than a new database transaction per block. This reduces a lot of overhead and is a significant speed up for IDB.

The batching is not fully atomic currently as an error committing to the database could leave the chain in a bad state, but we do validate blocks before attempting to connect them, so an invalid block cannot put a node in this state. It would have to be some kind of internal error or a bug.

