### PR TITLE
Update halo2curves on both zk and crypto rust crates

### DIFF
--- a/crypto/rust/Cargo.toml
+++ b/crypto/rust/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/project-illium/ilxd/crypto/rust"
 [dependencies]
 ff = { version = "0.13.0", features = ["derive"] }
 sha3 = "0.10"
-halo2curves = { version = "0.6.0", features = ["bits", "derive_serde"] }
+halo2curves = { version = "0.6.1", features = ["bits", "derive_serde"] }
 pasta_curves = { version = "0.5.0", features = ["repr-c", "serde"]}
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 bitvec = "1.0"

--- a/zk/rust/Cargo.toml
+++ b/zk/rust/Cargo.toml
@@ -15,7 +15,7 @@ bincode = "1.3.3"
 blake2s_simd = "1.0.2"
 ff = "0.13"
 flate2 = "1.0.26"
-halo2curves = { version = "0.6.0", features = ["bits", "derive_serde"] }
+halo2curves = { version = "0.6.1", features = ["bits", "derive_serde"] }
 hex = "0.4.3"
 itertools = "0.11"
 lazy_static = "1.4.0"

--- a/zk/rust/src/lib.rs
+++ b/zk/rust/src/lib.rs
@@ -295,7 +295,7 @@ fn create_public_params() -> PublicParams<Fr> {
 }
 
 fn create_proof(lurk_program: String, private_params: String, public_params: String, max_steps: usize) -> Result<(Vec<u8>, Vec<u8>, Vec<u8>), Box<dyn Error>> {
-    let store = &Store::<Fr>::default();
+    let store = &Arc::new(Store::<Fr>::default());
 
     let secret = Fr::random(OsRng);
     let priv_expr = store.read_with_default_state(private_params.as_str())?;
@@ -336,7 +336,7 @@ fn create_proof(lurk_program: String, private_params: String, public_params: Str
 
     let pp = get_public_params();
 
-    let (proof, _z0, zi, _num_steps) = supernova_prover.prove_from_frames(&pp, &frames, store)?;
+    let (proof, _z0, zi, _num_steps) = supernova_prover.prove_from_frames(&pp, &frames, store, None)?;
     let compressed_proof = proof.compress(&pp).unwrap();
 
     let mut ret_tag = zi[0].to_bytes();


### PR DESCRIPTION
halo2curves updated: `0.6.0` -> `0.6.1`

A compilation error occurred when trying to build a library that would use illium-zk as a dependency.

This commit corrects the type of the `store` parameter passed to
`supernova_prover.prove_from_frames` in the `create_proof` function from a direct
reference to an `Arc<Store<Fr>>`.

It aligns with the function's expectation for a
shared, thread-safe reference to the `Store` object. Additionally, it addresses
the missing `RecursiveSNARK` parameter by passing `None` to satisfy the method's
signature.

These changes ensure the function's compatibility with the
`supernova_prover`'s API and resolve previous compilation errors related to
argument mismatch.

The adjustment also includes a minor change to directly wrap the `Store` object
in an `Arc` at its point of creation, streamlining the management of the store's
lifecycle and sharing across threads or function calls where necessary.