### PR TITLE
fix: correct typos in struct tag descriptions (`cli/blockchain_service.go`)

### DIFF
--- a/cli/blockchain_service.go
+++ b/cli/blockchain_service.go
@@ -123,8 +123,8 @@ func (x *GetBlockchainInfo) Execute(args []string) error {
 
 type GetBlockInfo struct {
 	opts    *options
-	BlockID string `short:"i" long:"id" description:"Block ID to look up. Either us this or the height."`
-	Height  int    `short:"t" long:"height" description:"Block height. Either us this or the ID"`
+	BlockID string `short:"i" long:"id" description:"Block ID to look up. Either use this or the height."`
+	Height  int    `short:"t" long:"height" description:"Block height. Either use this or the ID"`
 }
 
 func (x *GetBlockInfo) Execute(args []string) error {
@@ -183,8 +183,8 @@ func (x *GetBlockInfo) Execute(args []string) error {
 
 type GetBlock struct {
 	opts    *options
-	BlockID string `short:"i" long:"id" description:"Block ID to look up. Either us this or the height."`
-	Height  int    `short:"t" long:"height" description:"Block height. Either us this or the ID"`
+	BlockID string `short:"i" long:"id" description:"Block ID to look up. Either use this or the height."`
+	Height  int    `short:"t" long:"height" description:"Block height. Either use this or the ID"`
 }
 
 func (x *GetBlock) Execute(args []string) error {
@@ -234,8 +234,8 @@ func (x *GetBlock) Execute(args []string) error {
 
 type GetCompressedBlock struct {
 	opts    *options
-	BlockID string `short:"i" long:"id" description:"Block ID to look up. Either us this or the height."`
-	Height  int    `short:"t" long:"height" description:"Block height. Either us this or the ID"`
+	BlockID string `short:"i" long:"id" description:"Block ID to look up. Either use this or the height."`
+	Height  int    `short:"t" long:"height" description:"Block height. Either use this or the ID"`
 }
 
 func (x *GetCompressedBlock) Execute(args []string) error {


### PR DESCRIPTION
Corrected typos in the descriptions of the struct tags in `blockchain_service.go`. The descriptions now correctly read "Either use this or the height" and "Either use this or the ID" instead of "Either us this or the height" and "Either us this or the ID".

Affected structs:
- GetBlockInfo
- GetBlock
- GetCompressedBlock