### PR TITLE
fix(dependencies): upgrade `time` crate to v0.3.36, zk rust build is broken

### DIFF
--- a/zk/rust/Cargo.lock
+++ b/zk/rust/Cargo.lock
@@ -1765,6 +1765,7 @@ dependencies = [
  "sha2",
  "sha3",
  "threadpool",
+ "time",
 ]
 
 [[package]]
@@ -3610,9 +3611,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -3633,9 +3634,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/zk/rust/Cargo.toml
+++ b/zk/rust/Cargo.toml
@@ -31,6 +31,7 @@ rand_core = { version = "0.6", default-features = false }
 sha2 = { version = "0.10.2" }
 sha3 = "0.10"
 serde = "1.0"
+time = "0.3.36"
 
 [dev-dependencies]
 threadpool = "1.8.1"


### PR DESCRIPTION
Fixes compilation issue with Rust 1.80.0

This commit upgrades the `time` crate from version 0.3.34 to 0.3.36 to address a compilation error caused by an API change in Rust 1.80.0. The error, specifically a type inference issue in the `format_description::parse::mod` module, required updating the `time` crate to v0.3.35 or higher.

Error before the fix:
<img width="1098" alt="Screenshot 2024-10-05 at 2 03 57 PM" src="https://github.com/user-attachments/assets/6d51564e-d6d7-486e-bffe-04165b7ecbdc">

```
Compiling time v0.3.34 error[E0282]: type annotations needed for Box<_> --> /Users/gubatron/.cargo/registry/src/index.crates.io-6f17d22bba15001f/time-0.3.34/src/format_description/parse/mod.rs:83:9 83 | let items = format_items ^^^^^ 86 | Ok(items.into()) ---- type must be known at this point
```

The fix involved upgrading the `time` crate to version 0.3.36, resolving the inference error and allowing the project to successfully compile with Rust 1.80.0.

This update does not add any new dependencies, maintaining the existing project structure while ensuring compatibility with the latest Rust toolchain.

<img width="775" alt="Screenshot 2024-10-05 at 2 11 35 PM" src="https://github.com/user-attachments/assets/b07fa776-a05a-4032-8432-25e817c8eebf">

Compilation is successful post-upgrade, with no errors.