### PR TITLE
Dep fix blst 0.3.13

### DIFF
--- a/zk/rust/Cargo.lock
+++ b/zk/rust/Cargo.lock
@@ -1765,6 +1765,7 @@ dependencies = [
  "sha2",
  "sha3",
  "threadpool",
+ "time",
 ]
 
 [[package]]
@@ -3610,9 +3611,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -3633,9 +3634,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/zk/rust/Cargo.lock
+++ b/zk/rust/Cargo.lock
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94087b935a822949d3291a9989ad2b2051ea141eda0fd4e478a75f6aa3e604b"
+checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
 dependencies = [
  "cc",
  "glob",
@@ -1747,6 +1747,7 @@ dependencies = [
  "bellpepper-core",
  "bincode",
  "blake2s_simd",
+ "blst",
  "ff",
  "flate2",
  "halo2curves",

--- a/zk/rust/Cargo.toml
+++ b/zk/rust/Cargo.toml
@@ -31,6 +31,7 @@ rand_core = { version = "0.6", default-features = false }
 sha2 = { version = "0.10.2" }
 sha3 = "0.10"
 serde = "1.0"
+time = "0.3.36"
 
 [dev-dependencies]
 threadpool = "1.8.1"

--- a/zk/rust/Cargo.toml
+++ b/zk/rust/Cargo.toml
@@ -13,6 +13,7 @@ bellpepper = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev" }
 bellpepper-core = { version = "0.4.0" }
 bincode = "1.3.3"
 blake2s_simd = "1.0.2"
+blst = "0.3.13"
 ff = "0.13"
 flate2 = "1.0.26"
 halo2curves = { version = "0.6.0", features = ["bits", "derive_serde"] }


### PR DESCRIPTION
time and blst as implicit dependencies break the ilxd_zk build in macos x86_64.
explicitly including these newer versions compiles these crates without issue in macos x86_64 (Sonoma 14.6.1)